### PR TITLE
Remove unused bcrypt module

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "build": "uglifyjs utensils.js --mangle --source-map utensils-min.map -o utensils-min.js"
   },
   "dependencies": {
-    "bcrypt": "~0.7.7",
     "q": "~1.0.1",
     "underscore": "~1.6.0"
   },


### PR DESCRIPTION
We're using Utensils in our Node app, but can't upgrade our Node version to 0.12.x because the bcrypt dependency in utensils conflicts. It doesn't seem to be used. We would love to have it removed and a new version of this module pushed up to npm! 

Thanks,
Laura

This would resolve my earlier issue, #1 
